### PR TITLE
workaround the wxWidgets 2.8 dependency when other versions are installed

### DIFF
--- a/src/trelby.py
+++ b/src/trelby.py
@@ -1,5 +1,8 @@
 # -*- coding: iso-8859-1 -*-
 
+import wxversion
+wxversion.select('2.8')
+
 from error import *
 import autocompletiondlg
 import cfgdlg


### PR DESCRIPTION
introduced dependency on python-wxversion in ubuntu.