### PR TITLE
document installation dependencies

### DIFF
--- a/README.dev
+++ b/README.dev
@@ -67,6 +67,22 @@ Then, on Windows, to create the installer:
 
 Your freshly created Setup-Trelby-<version>.exe should be ready.
 
+2.6  Preparing for a Linux Installation
+=======================================
+
+Tested on an ubuntu laptop, reporting: jessie/sid.
+
+Expressed as a puppet Package[] resource, 
+I found the following libraries required:
+
+  package { [ 'python-lxml',
+              'libwxgtk2.8-0',
+              'libwxbase2.8-0',
+              'python-wxgtk2.8',
+              'python-wxversion',
+              'libwxgtk-media2.8-0' ]:
+    ensure => present
+  }
 
 3. Running Trelby in test mode
 ==============================


### PR DESCRIPTION
Hope this is helpful.  I found that your .deb installer failed to specify and drag in required dependencies.  I intend to write a complete puppet module to manage installation of this application, at least for myself, and if it gets mature enough perhaps for publication to the forge.puppetlabs.com site.  Will try to contribute back here from time to time if I have anything which might prove useful to others.  Thanks again for this tool.  