### PR TITLE
Add option for blinking cursor

### DIFF
--- a/src/cfgdlg.py
+++ b/src/cfgdlg.py
@@ -261,6 +261,11 @@ class DisplayPanel(wx.Panel):
             choices = [ "None", "Normal", "Normal + unadjusted   " ])
         vsizer.Add(self.pbRb)
 
+        self.blinkingCursorCheckBox = wx.CheckBox(
+            self, -1, "Use blinking cursor")
+        wx.EVT_CHECKBOX(self, self.blinkingCursorCheckBox.GetId(), self.OnMisc)
+        vsizer.Add(self.blinkingCursorCheckBox, 0, wx.EXPAND | wx.BOTTOM | wx.TOP, 10)
+
         self.fontsLb.SetSelection(0)
         self.updateFontLb()
 
@@ -306,6 +311,7 @@ class DisplayPanel(wx.Panel):
     def OnMisc(self, event = None):
         self.cfg.fontYdelta = util.getSpinValue(self.spacingEntry)
         self.cfg.pbi = self.pbRb.GetSelection()
+        self.cfg.useBlinkingCursor = bool(self.blinkingCursorCheckBox.IsChecked())
 
     def updateFontLb(self):
         names = ["Normal", "Bold", "Italic", "Bold-Italic"]
@@ -335,6 +341,7 @@ class DisplayPanel(wx.Panel):
     def cfg2gui(self):
         self.spacingEntry.SetValue(self.cfg.fontYdelta)
         self.pbRb.SetSelection(self.cfg.pbi)
+        self.blinkingCursorCheckBox.SetValue(self.cfg.useBlinkingCursor)
 
 class ElementsPanel(wx.Panel):
     def __init__(self, parent, id, cfg):

--- a/src/config.py
+++ b/src/config.py
@@ -1006,6 +1006,9 @@ class ConfigGlobal:
         v.addInt("pbi", PBI_REAL, "PageBreakIndicators", PBI_FIRST,
                     PBI_LAST)
 
+        # whether to use blinking cursor
+        v.addBool("useBlinkingCursor", False, "useBlinkingCursor")
+
         # PDF viewer program and args. defaults are empty since generating
         # them is a complex process handled by findPDFViewer.
         v.addStrUnicode("pdfViewerPath", u"", "PDF/ViewerPath")

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -206,6 +206,18 @@ class MyCtrl(wx.Control):
         self.createEmptySp()
         self.updateScreen(redraw = False)
 
+        self.blinkingCursorVisibleFlag = True
+        self.blinkingCursorTimer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self.OnBlinkingCursorTimerEvent,
+			self.blinkingCursorTimer)
+        self.blinkingCursorTimer.Start(500)
+
+    def OnBlinkingCursorTimerEvent(self, event):
+        self.blinkingCursorVisibleFlag = not self.blinkingCursorVisibleFlag
+
+        if cfgGl.useBlinkingCursor:
+            self.updateScreen()
+
     def OnChangeType(self, event):
         cs = screenplay.CommandState()
 
@@ -1515,12 +1527,13 @@ class MyCtrl(wx.Control):
                                 size.width, 0)
 
                 if i == self.sp.line:
-                    posX = t.x
-                    cursorY = y
-                    acFi = fi
-                    dc.SetPen(cfgGui.cursorPen)
-                    dc.SetBrush(cfgGui.cursorBrush)
-                    dc.DrawRectangle(t.x + self.sp.column * fx, y, fx, fi.fy)
+                    if not cfgGl.useBlinkingCursor or self.blinkingCursorVisibleFlag:
+                        posX = t.x
+                        cursorY = y
+                        acFi = fi
+                        dc.SetPen(cfgGui.cursorPen)
+                        dc.SetBrush(cfgGui.cursorBrush)
+                        dc.DrawRectangle(t.x + self.sp.column * fx, y, fx, fi.fy)
 
             if len(t.text) != 0:
                 tl = texts.get(fi.font)


### PR DESCRIPTION
Fixes #148.

To use the blinking cursor:

1. Select "File --> Settings --> Change..."
2. Select "Display"
3. Tick the "Use blinking cursor" box at the bottom
4. Click "Apply"

Video demo below:

![blinking-cursor-demo](https://user-images.githubusercontent.com/24422213/50553952-7bdc7d80-0d16-11e9-92ec-8d82cd8d3fae.gif)

