### PR TITLE
Add thin cursor option

### DIFF
--- a/src/cfgdlg.py
+++ b/src/cfgdlg.py
@@ -260,6 +260,11 @@ class DisplayPanel(wx.Panel):
             style = wx.RA_SPECIFY_COLS, majorDimension = 1,
             choices = [ "None", "Normal", "Normal + unadjusted   " ])
         vsizer.Add(self.pbRb)
+        
+        self.useThinCursor = wx.CheckBox(
+            self, -1, "Use thin cursor")
+        wx.EVT_CHECKBOX(self, self.useThinCursor.GetId(), self.OnMisc)
+        vsizer.Add(self.useThinCursor)        
 
         self.fontsLb.SetSelection(0)
         self.updateFontLb()
@@ -306,6 +311,7 @@ class DisplayPanel(wx.Panel):
     def OnMisc(self, event = None):
         self.cfg.fontYdelta = util.getSpinValue(self.spacingEntry)
         self.cfg.pbi = self.pbRb.GetSelection()
+        self.cfg.useThinCursor = self.useThinCursor.GetValue()
 
     def updateFontLb(self):
         names = ["Normal", "Bold", "Italic", "Bold-Italic"]
@@ -335,6 +341,7 @@ class DisplayPanel(wx.Panel):
     def cfg2gui(self):
         self.spacingEntry.SetValue(self.cfg.fontYdelta)
         self.pbRb.SetSelection(self.cfg.pbi)
+        self.useThinCursor.SetValue(self.cfg.useThinCursor)
 
 class ElementsPanel(wx.Panel):
     def __init__(self, parent, id, cfg):

--- a/src/config.py
+++ b/src/config.py
@@ -1005,6 +1005,9 @@ class ConfigGlobal:
         # page break indicators to show
         v.addInt("pbi", PBI_REAL, "PageBreakIndicators", PBI_FIRST,
                     PBI_LAST)
+                    
+        # whether to use a thin cursor
+        v.addBool("useThinCursor", False, "UseThinCursor")
 
         # PDF viewer program and args. defaults are empty since generating
         # them is a complex process handled by findPDFViewer.

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -1520,7 +1520,11 @@ class MyCtrl(wx.Control):
                     acFi = fi
                     dc.SetPen(cfgGui.cursorPen)
                     dc.SetBrush(cfgGui.cursorBrush)
-                    dc.DrawRectangle(t.x + self.sp.column * fx, y, fx, fi.fy)
+                    
+                    if cfgGl.useThinCursor:
+                        dc.DrawRectangle(t.x + self.sp.column * fx, y, 2, fi.fy)
+                    else:
+                        dc.DrawRectangle(t.x + self.sp.column * fx, y, fx, fi.fy)
 
             if len(t.text) != 0:
                 tl = texts.get(fi.font)


### PR DESCRIPTION
Fixes #44.

To use the thin cursor setting:

1. Select "File --> Settings --> Change..."
2. Select "Display"
3. Tick the "Use thin cursor" check-box at the bottom
4. Click "OK"

Video demo below:

![thin-cursor-demo](https://user-images.githubusercontent.com/24422213/50576656-5452f580-0e7b-11e9-9178-865ca9070c89.gif)
