### PR TITLE
Why has this taken over 3 years to actually be added?

### DIFF
--- a/src/trelby.py
+++ b/src/trelby.py
@@ -1,6 +1,8 @@
 # -*- coding: iso-8859-1 -*-
 
 from error import *
+import wxversion
+wxversion.select('2.8')
 import autocompletiondlg
 import cfgdlg
 import charmapdlg


### PR DESCRIPTION
This was first brought up October 2015. It ensures trelby requests wx 2.8. This prevents the issue where it would grab 3.0 even if 2.8 was installed.

Additionally, the Debian packages for Python wxgtk 2.8 are gone for stretch. However, Ubuntu has compatible versions that can be used instead.