### PR TITLE
Support for Alt Gr key

### DIFF
--- a/src/trelby.py
+++ b/src/trelby.py
@@ -1328,14 +1328,10 @@ class MyCtrl(wx.Control):
 
         isNormalChar    = not ev.ControlDown() and not ev.AltDown() and \
                           util.isValidInputChar(kc)
-        # TODO: Check for keyboard shortcuts.
-        isUnicodeChar   = ev.AltDown() and uc != wx.WXK_NONE
+        isUnicodeChar   = ev.GetModifiers() == wx.MOD_ALTGR and \
+                          uc != wx.WXK_NONE
 
         if isNormalChar or isUnicodeChar:
-            # WX2.6-FIXME: we should probably use GetUnicodeKey() (dunno
-            # how to get around the isValidInputChar test in the preceding
-            # line, need to test what GetUnicodeKey() returns on
-            # non-input-character events)
 
             addChar = True
 

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -1320,13 +1320,18 @@ class MyCtrl(wx.Control):
 
     def OnKeyChar(self, ev):
         kc = ev.GetKeyCode()
+        uc = ev.GetUnicodeKey()
 
         cs = screenplay.CommandState()
         cs.mark = bool(ev.ShiftDown())
         scrollDirection = config.SCROLL_CENTER
 
-        if not ev.ControlDown() and not ev.AltDown() and \
-               util.isValidInputChar(kc):
+        isNormalChar    = not ev.ControlDown() and not ev.AltDown() and \
+                          util.isValidInputChar(kc)
+        # TODO: Check for keyboard shortcuts.
+        isUnicodeChar   = ev.AltDown() and uc != wx.WXK_NONE
+
+        if isNormalChar or isUnicodeChar:
             # WX2.6-FIXME: we should probably use GetUnicodeKey() (dunno
             # how to get around the isValidInputChar test in the preceding
             # line, need to test what GetUnicodeKey() returns on


### PR DESCRIPTION
Fixes #403. Allows entering characters which use the Alt Gr key. I tested on Ubuntu 14 and Windows 7 using the Swedish keyboard layout with Alt Gr + A (ª), Alt Gr + M (µ), and it works fine for me.