### PR TITLE
Add double-click and triple-click selection

### DIFF
--- a/src/screenplay.py
+++ b/src/screenplay.py
@@ -2909,6 +2909,29 @@ Generated with <a href="http://www.trelby.org">Trelby</a>.</p>
         self.line = len(self.lines) - 1
         self.column = len(self.lines[self.line].text)
 
+    # select the current word
+    def selectCurrentWordCmd(self):
+		# get current line text
+        current_line = self.lines[self.line]
+        text = current_line.text
+
+		# find next and previous space
+        word_start = text.rfind(" ", 0, self.column)
+        word_end = text.find(" ", self.column)
+
+        # add 1 to word start to cover both
+        # 1) result = -1 (space not found) OR
+        # 2) advance beyond the "found" space
+        word_start += 1
+
+		# don't go past line end
+        if word_end == -1:
+            word_end = len(text)
+
+		# highlight the word
+        self.setMark(self.line, word_start)
+        self.column = word_end
+
     def insertForcedLineBreakCmd(self, cs):
         u = undo.ManyElems(self, undo.CMD_MISC, self.line, 1, 1)
 

--- a/src/screenplay.py
+++ b/src/screenplay.py
@@ -2910,30 +2910,35 @@ Generated with <a href="http://www.trelby.org">Trelby</a>.</p>
         self.column = len(self.lines[self.line].text)
 
     # select the current line
-    def selectCurrentLineCmd(self):
+    def selectCurrentLine(self):
         self.setMark(self.line, 0)
         self.column = len(self.lines[self.line].text)
 
     # select the current word
-    def selectCurrentWordCmd(self):
-		# get current line text
+    def selectCurrentWord(self):
+        # get current line text
         current_line = self.lines[self.line]
         text = current_line.text
 
-		# find next and previous space
+        # find next and previous space
         word_start = text.rfind(" ", 0, self.column)
         word_end = text.find(" ", self.column)
 
-        # add 1 to word start to cover both
-        # 1) result = -1 (space not found) OR
-        # 2) advance beyond the "found" space
-        word_start += 1
+        if word_start < 0:
+            # no previous space, so select from start of line
+            word_start = 0
+        else:
+            # space found, so select from just after it
+            word_start += 1
 
-		# don't go past line end
         if word_end == -1:
+            # no next space, so select till end of line
             word_end = len(text)
+        else:
+            # space found, so select till just before it
+            word_end -= 1
 
-		# highlight the word
+        # highlight the word
         self.setMark(self.line, word_start)
         self.column = word_end
 

--- a/src/screenplay.py
+++ b/src/screenplay.py
@@ -2909,6 +2909,11 @@ Generated with <a href="http://www.trelby.org">Trelby</a>.</p>
         self.line = len(self.lines) - 1
         self.column = len(self.lines[self.line].text)
 
+    # select the current line
+    def selectCurrentLineCmd(self):
+        self.setMark(self.line, 0)
+        self.column = len(self.lines[self.line].text)
+
     # select the current word
     def selectCurrentWordCmd(self):
 		# get current line text

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -197,7 +197,7 @@ class MyCtrl(wx.Control):
         wx.EVT_ERASE_BACKGROUND(self, self.OnEraseBackground)
         wx.EVT_LEFT_DOWN(self, self.OnLeftDown)
         wx.EVT_LEFT_UP(self, self.OnLeftUp)
-        wx.EVT_LEFT_DCLICK(self, self.OnLeftDown)
+        wx.EVT_LEFT_DCLICK(self, self.OnLeftDoubleClick)
         wx.EVT_RIGHT_DOWN(self, self.OnRightDown)
         wx.EVT_MOTION(self, self.OnMotion)
         wx.EVT_MOUSEWHEEL(self, self.OnMouseWheel)
@@ -554,6 +554,25 @@ class MyCtrl(wx.Control):
                 self.__class__.screenBuf = sb
 
         self.makeLineVisible(self.sp.line)
+
+    def OnLeftDoubleClick(self, event, mark = False):
+        # Clear mark.
+        if not self.mouseSelectActive:
+            self.sp.clearMark()
+            self.updateScreen()
+
+        # Get coords.
+        pos = event.GetPosition()
+        line, col = gd.vm.pos2linecol(self, pos.x, pos.y)
+
+        # Do not start selecting anything.
+        self.mouseSelectActive = False
+
+        # Select word.
+        if line is not None:
+            self.sp.gotoPos(line, col, mark)
+            self.sp.selectCurrentWordCmd()
+            self.updateScreen()
 
     def OnLeftDown(self, event, mark = False):
         if not self.mouseSelectActive:

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -205,7 +205,7 @@ class MyCtrl(wx.Control):
 
         self.createEmptySp()
         self.updateScreen(redraw = False)
-        
+
         self.lastDoubleClickTime = 0
 
     def OnChangeType(self, event):
@@ -560,7 +560,7 @@ class MyCtrl(wx.Control):
     def OnLeftDoubleClick(self, event, mark = False):
         # Store the timestamp so we can check for triple-clicks.
         self.lastDoubleClickTime = event.GetTimestamp()
-        
+
         # Clear mark.
         if not self.mouseSelectActive:
             self.sp.clearMark()
@@ -576,19 +576,19 @@ class MyCtrl(wx.Control):
         # Select word.
         if line is not None:
             self.sp.gotoPos(line, col, mark)
-            self.sp.selectCurrentWordCmd()
+            self.sp.selectCurrentWord()
             self.updateScreen()
 
     def OnLeftDown(self, event, mark = False):
         # Check for triple-clicks.
         time = event.GetTimestamp()
         duration = time - self.lastDoubleClickTime
-        
+
         if duration < 200:
             # We have a triple-click.
             self.OnLeftTripleClick(event, mark)
             return
-        
+
         if not self.mouseSelectActive:
             self.sp.clearMark()
             self.updateScreen()
@@ -611,8 +611,8 @@ class MyCtrl(wx.Control):
 
         if not cd or ((len(cd.lines) == 1) and (len(cd.lines[0].text) < 2)):
             self.sp.clearMark()
-            
-    def OnLeftTripleClick(self, event, mark = False):        
+
+    def OnLeftTripleClick(self, event, mark = False):
         # Clear mark.
         if not self.mouseSelectActive:
             self.sp.clearMark()
@@ -628,7 +628,7 @@ class MyCtrl(wx.Control):
         # Select current line.
         if line is not None:
             self.sp.gotoPos(line, col, mark)
-            self.sp.selectCurrentLineCmd()
+            self.sp.selectCurrentLine()
             self.updateScreen()
 
     def OnMotion(self, event):
@@ -1395,11 +1395,11 @@ class MyCtrl(wx.Control):
             if addChar:
                 cs.char = chr(kc)
 
-                if opts.isTest and (cs.char == "ï¿½"):
+                if opts.isTest and (cs.char == "å"):
                     self.loadFile(u"sample.trelby")
-                elif opts.isTest and (cs.char == "ï¿½"):
+                elif opts.isTest and (cs.char == "¤"):
                     self.cmdTest(cs)
-                elif opts.isTest and (cs.char == "ï¿½"):
+                elif opts.isTest and (cs.char == "½"):
                     self.cmdSpeedTest(cs)
                 else:
                     self.sp.addCharCmd(cs)

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -205,6 +205,8 @@ class MyCtrl(wx.Control):
 
         self.createEmptySp()
         self.updateScreen(redraw = False)
+        
+        self.lastDoubleClickTime = 0
 
     def OnChangeType(self, event):
         cs = screenplay.CommandState()
@@ -556,6 +558,9 @@ class MyCtrl(wx.Control):
         self.makeLineVisible(self.sp.line)
 
     def OnLeftDoubleClick(self, event, mark = False):
+        # Store the timestamp so we can check for triple-clicks.
+        self.lastDoubleClickTime = event.GetTimestamp()
+        
         # Clear mark.
         if not self.mouseSelectActive:
             self.sp.clearMark()
@@ -575,6 +580,15 @@ class MyCtrl(wx.Control):
             self.updateScreen()
 
     def OnLeftDown(self, event, mark = False):
+        # Check for triple-clicks.
+        time = event.GetTimestamp()
+        duration = time - self.lastDoubleClickTime
+        
+        if duration < 200:
+            # We have a triple-click.
+            self.OnLeftTripleClick(event, mark)
+            return
+        
         if not self.mouseSelectActive:
             self.sp.clearMark()
             self.updateScreen()
@@ -597,6 +611,25 @@ class MyCtrl(wx.Control):
 
         if not cd or ((len(cd.lines) == 1) and (len(cd.lines[0].text) < 2)):
             self.sp.clearMark()
+            
+    def OnLeftTripleClick(self, event, mark = False):        
+        # Clear mark.
+        if not self.mouseSelectActive:
+            self.sp.clearMark()
+            self.updateScreen()
+
+        # Get coords.
+        pos = event.GetPosition()
+        line, col = gd.vm.pos2linecol(self, pos.x, pos.y)
+
+        # Do not start selecting anything.
+        self.mouseSelectActive = False
+
+        # Select current line.
+        if line is not None:
+            self.sp.gotoPos(line, col, mark)
+            self.sp.selectCurrentLineCmd()
+            self.updateScreen()
 
     def OnMotion(self, event):
         if event.LeftIsDown():
@@ -1362,11 +1395,11 @@ class MyCtrl(wx.Control):
             if addChar:
                 cs.char = chr(kc)
 
-                if opts.isTest and (cs.char == "å"):
+                if opts.isTest and (cs.char == "ï¿½"):
                     self.loadFile(u"sample.trelby")
-                elif opts.isTest and (cs.char == "¤"):
+                elif opts.isTest and (cs.char == "ï¿½"):
                     self.cmdTest(cs)
-                elif opts.isTest and (cs.char == "½"):
+                elif opts.isTest and (cs.char == "ï¿½"):
                     self.cmdSpeedTest(cs)
                 else:
                     self.sp.addCharCmd(cs)

--- a/tests/selection.py
+++ b/tests/selection.py
@@ -1,0 +1,34 @@
+import screenplay as scr
+import u
+
+# tests text selection
+
+# helper method to see actual values of strings
+def assertEquals(actual, expected):
+    if actual != expected:
+        print "actual   = [" + actual + "]"
+        print "expected = [" + expected + "]"
+    assert actual == expected
+
+def testSelectWord():
+    sp = u.new()
+
+    sp.paste([scr.Line(text = "One Two Three", lt = scr.ACTION)])
+
+    sp.gotoPos(0, 0)
+    sp.selectCurrentWord()
+    cd = sp.getSelectedAsCD(False)
+
+    assertEquals(cd.lines[0].text, "One")
+
+    sp.gotoPos(0, len("One "))
+    sp.selectCurrentWord()
+    cd = sp.getSelectedAsCD(False)
+
+    assertEquals(cd.lines[0].text, "Two")
+
+    sp.gotoPos(0, len("One Two "))
+    sp.selectCurrentWord()
+    cd = sp.getSelectedAsCD(False)
+
+    assertEquals(cd.lines[0].text, "Three")


### PR DESCRIPTION
Double-clicking selects the current word (using space character as the delimiter).

Triple-clicking selects the current line.