### PR TITLE
(WIP) Add auto-save feature

### DIFF
--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -1253,6 +1253,12 @@
 		<para>'Lines to scroll per mouse wheel event' needs no
 		explaining.</para>
 
+		<para>'Automatically save scripts every X minutes' - tick
+		the checkbox to enable automatic saving. Set the interval in
+		minutes using the edit box. If the box is ticked, Trelby will
+		save all open scripts at the chosen interval - except the new
+		ones which haven't been saved before.</para>
+
 	  </sect2>
 
 	</sect1>

--- a/src/cfgdlg.py
+++ b/src/cfgdlg.py
@@ -1109,6 +1109,18 @@ class MiscPanel(wx.Panel):
         self.addSpin("wheelScroll", "Lines to scroll per mouse wheel event:",
                      self, vsizer, "mouseWheelLines")
 
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.autoSaveCb = wx.CheckBox(self, -1, "Automatically save scripts"
+                                                " every")
+        hsizer.Add(self.autoSaveCb, 0, wx.ALIGN_CENTER_VERTICAL, 10)
+        self.addSpin("autoSaveInterval", "",
+                     self, hsizer, "autoSaveInterval")
+        hsizer.Add(wx.StaticText(self, -1, " minutes"), 0,
+                   wx.ALIGN_CENTER_VERTICAL, 10)
+        vsizer.Add(hsizer, 0, 0, pad)
+
+        wx.EVT_CHECKBOX(self, self.autoSaveCb.GetId(), self.OnMisc)
+
         self.cfg2gui()
 
         util.finishWindow(self, vsizer, center = False)
@@ -1151,6 +1163,10 @@ class MiscPanel(wx.Panel):
         self.cfg.paginateInterval = util.getSpinValue(self.paginateEntry)
         self.cfg.mouseWheelLines = util.getSpinValue(self.wheelScrollEntry)
         self.cfg.splashTime = util.getSpinValue(self.splashTimeEntry)
+
+        self.cfg.autoSaveEnabled = self.autoSaveCb.IsChecked()
+        self.cfg.autoSaveInterval = \
+            util.getSpinValue(self.autoSaveIntervalEntry)
 
     def OnBrowse(self, event):
         dlg = wx.DirDialog(
@@ -1200,6 +1216,9 @@ class MiscPanel(wx.Panel):
         self.paginateEntry.SetValue(self.cfg.paginateInterval)
         self.wheelScrollEntry.SetValue(self.cfg.mouseWheelLines)
         self.splashTimeEntry.SetValue(self.cfg.splashTime)
+
+        self.autoSaveCb.SetValue(self.cfg.autoSaveEnabled)
+        self.autoSaveIntervalEntry.SetValue(self.cfg.autoSaveInterval)
 
 class ElementsGlobalPanel(wx.Panel):
     def __init__(self, parent, id, cfg):

--- a/src/config.py
+++ b/src/config.py
@@ -977,8 +977,14 @@ class ConfigGlobal:
         # how many lines to scroll per mouse wheel event
         v.addInt("mouseWheelLines", 4, "MouseWheelLines", 1, 50)
 
+        # interval in minutes between auto-saving
+        v.addInt("autoSaveInterval", 15, "AutoSaveInterval", 1, 1000)
+
         # interval in seconds between automatic pagination (0 = disabled)
         v.addInt("paginateInterval", 1, "PaginateInterval", 0, 10)
+
+        # whether auto-save is enabled
+        v.addBool("autoSaveEnabled", False, "AutoSaveEnabled")
 
         # whether to check script for errors before export / print
         v.addBool("checkOnExport", True, "CheckScriptForErrors")


### PR DESCRIPTION
For #394. Adds the option to automatically save scripts every X minutes. The option can be found in _File --> Settings --> Change..._, in the "Misc" section, at the bottom. It is disabled (unchecked) by default.

Demo below:

![auto-save-demo](https://user-images.githubusercontent.com/24422213/78584581-84fab980-788c-11ea-9a14-6748c2437241.gif)

NOTE: This only auto-saves files which have already been saved before, not new files. The reason for this is that I don't like to be suddenly prompted to enter a file-name for a script I haven't saved before.

**Still To Do:**

* Test with many large scripts open at once - does this introduce a noticable delay?
* Test with a file becoming read-only or otherwise unreachable (e.g. disconnected external drive) before the autosave.
* Test extreme values (0, 10000, etc.) for interval checkbox.
